### PR TITLE
feat: add zizmor version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to the "zizmor-vscode" extension will be documented in this file.
 
-## [0.1.0] - 2025-06-27
+## 0.0.2
+
+### Added
+
+* The extension now checks `zizmor`'s version, and fails with a more
+  useful error message if the installed version of `zizmor` is too old
+  (or if `zizmor` is not installed at all)
+
+## 0.0.1
 
 This is the first official release of [zizmor](https://zizmor.sh) for VS Code!
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import {
     LanguageClient,
     LanguageClientOptions,
@@ -11,6 +13,9 @@ import {
 
 let client: LanguageClient;
 
+const execAsync = promisify(exec);
+const MIN_ZIZMOR_VERSION = '1.11.0';
+
 /**
  * Expands tilde (~) in file paths to the user's home directory
  */
@@ -19,6 +24,58 @@ function expandTilde(filePath: string): string {
         return path.join(os.homedir(), filePath.slice(1));
     }
     return filePath;
+}
+
+/**
+ * Compares two semantic version strings
+ * Returns: -1 if version1 < version2, 0 if equal, 1 if version1 > version2
+ */
+function compareVersions(version1: string, version2: string): number {
+    const v1Parts = version1.split('.').map(Number);
+    const v2Parts = version2.split('.').map(Number);
+
+    const maxLength = Math.max(v1Parts.length, v2Parts.length);
+
+    for (let i = 0; i < maxLength; i++) {
+        const v1Part = v1Parts[i] || 0;
+        const v2Part = v2Parts[i] || 0;
+
+        if (v1Part < v2Part) {
+            return -1;
+        }
+        if (v1Part > v2Part) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Checks if the zizmor executable meets the minimum version requirement
+ */
+async function checkZizmorVersion(executablePath: string): Promise<{ isValid: boolean; version?: string; error?: string }> {
+    try {
+        const { stdout } = await execAsync(`"${executablePath}" --version`);
+        const versionMatch = stdout.trim().match(/(\d+\.\d+\.\d+)/);
+
+        if (!versionMatch) {
+            return {
+                isValid: false,
+                error: `Could not parse version from zizmor output: ${stdout.trim()}`
+            };
+        }
+
+        const version = versionMatch[1];
+        const isValid = compareVersions(version, MIN_ZIZMOR_VERSION) >= 0;
+
+        return { isValid, version };
+    } catch (error: any) {
+        return {
+            isValid: false,
+            error: `Failed to execute zizmor --version: ${error.message}`
+        };
+    }
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -33,6 +90,29 @@ export function activate(context: vscode.ExtensionContext) {
     // Get the path to the zizmor executable
     const rawExecutablePath = config.get<string>('executablePath', 'zizmor');
     const executablePath = expandTilde(rawExecutablePath);
+
+    // Check zizmor version before starting the language server
+    checkZizmorVersion(executablePath).then(versionCheck => {
+        if (!versionCheck.isValid) {
+            const errorMessage = versionCheck.version
+                ? `zizmor version ${versionCheck.version} is too old. This extension requires zizmor ${MIN_ZIZMOR_VERSION} or newer. Please update zizmor and try again.`
+                : `Failed to check zizmor version: ${versionCheck.error}. Please ensure zizmor is installed and accessible at "${executablePath}".`;
+
+            console.error('zizmor version check failed:', errorMessage);
+            vscode.window.showErrorMessage(errorMessage);
+            return;
+        }
+
+        console.log(`zizmor version ${versionCheck.version} meets minimum requirement (${MIN_ZIZMOR_VERSION})`);
+        startLanguageServer(context, executablePath);
+    }).catch(error => {
+        const errorMessage = `Failed to start zizmor language server: ${error.message}`;
+        console.error('zizmor activation failed:', error);
+        vscode.window.showErrorMessage(errorMessage);
+    });
+}
+
+function startLanguageServer(context: vscode.ExtensionContext, executablePath: string) {
 
     // Define the server options
     const serverExecutable: Executable = {


### PR DESCRIPTION
This produces a more reasonable error message
when `zizmor` is not installed or is too old,
rather than trying to restart the extension
until it hard-fails.