### PR TITLE
fix: don't sync zizmor.executablePath

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
                 "zizmor.executablePath": {
                     "type": "string",
                     "default": "zizmor",
-                    "description": "Path to the zizmor executable"
+                    "description": "Path to the zizmor executable",
+                    "scope": "machine-overridable"
                 },
                 "zizmor.trace.server": {
                     "type": "string",


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first). (https://github.com/zizmorcore/zizmor-vscode/issues/4#issuecomment-3478682704)

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

When using vscode settings sync, omit this key. Allow overriding per-folder because why not.
