### PR TITLE
fix: handle zizmor not found case gracefullier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 !.vscode/
+.vscode/settings.json
 
 out/
 dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
-                "@types/node": "16.x",
+                "@types/node": "^22.0.0",
                 "@types/vscode": "^1.105.0",
                 "@typescript-eslint/eslint-plugin": "^5.45.0",
                 "@typescript-eslint/parser": "^5.45.0",
@@ -964,11 +964,14 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.18.126",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "version": "22.19.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.0.tgz",
+            "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
@@ -6223,6 +6226,13 @@
             "engines": {
                 "node": ">=20.18.1"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unicorn-magic": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "vsce:publish": "vsce publish"
     },
     "devDependencies": {
-        "@types/node": "16.x",
+        "@types/node": "^22.0.0",
         "@types/vscode": "^1.105.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",

--- a/src/which.ts
+++ b/src/which.ts
@@ -1,0 +1,83 @@
+import { join, delimiter, sep, posix } from 'node:path';
+import * as fs from 'node:fs/promises';
+
+/** Options bag */
+export interface Options {
+    /** Use instead of the PATH environment variable. */
+    path?: string | undefined;
+    /** Use instead of the PATHEXT environment variable. */
+    pathExt?: string | undefined;
+    /** Use instead of the platform's native path separator. */
+    delimiter?: string | undefined;
+}
+
+const isWindows = process.platform === 'win32';
+
+/**
+ * Used to check for slashed in commands passed in.
+ * Always checks for the POSIX separator on all platforms,
+ * and checks for the current separator when not on a POSIX platform.
+ */
+const rSlash = new RegExp(`[${posix.sep}${sep === posix.sep ? '' : sep}]`.replace(/(\\)/g, '\\$1'));
+const rRel = new RegExp(`^\\.${rSlash.source}`);
+
+const getPathInfo = (cmd: string, {
+    path: optPath = process.env.PATH,
+    pathExt: optPathExt = process.env.PATHEXT,
+    delimiter: optDelimiter = delimiter,
+}: Partial<Options>) => {
+    // If it has a slash, then we don't bother searching the pathenv.
+    // just check the file itself, and that's it.
+    const pathEnv = cmd.match(rSlash) ? [''] : [
+        // Windows always checks the cwd first.
+        ...(isWindows ? [process.cwd()] : []),
+        ...(optPath ?? '').split(optDelimiter),
+    ];
+
+    if (isWindows) {
+        const pathExtExe = optPathExt ??
+            ['.EXE', '.CMD', '.BAT', '.COM'].join(optDelimiter);
+        const pathExt = pathExtExe.split(optDelimiter).flatMap((item) => [item, item.toLowerCase()]);
+        if (cmd.includes('.') && pathExt[0] !== '') {
+            pathExt.unshift('');
+        }
+        return { pathEnv, pathExt };
+    }
+
+    return { pathEnv, pathExt: [''] };
+};
+
+const getPathPart = (raw: string, cmd: string) => {
+    const pathPart = /^".*"$/.test(raw) ? raw.slice(1, -1) : raw;
+    const prefix = !pathPart && rRel.test(cmd) ? cmd.slice(0, 2) : '';
+    return prefix + join(pathPart, cmd);
+};
+
+/**
+ * Emulate POSIX `command -v` cross-playform.
+ *
+ * @param cmd - command to search the PATH for.
+ * @param options - options to customize the lookup.
+ * @returns The path to the desired executable, or `undefined` if not found.
+ */
+export const which = async (
+    cmd: string,
+    options: Options = {},
+): Promise<string | undefined> => {
+    const { pathEnv, pathExt } = getPathInfo(cmd, options);
+
+    for (const envPart of pathEnv) {
+        const p = getPathPart(envPart, cmd);
+
+        for (const ext of pathExt) {
+            const candidate = p + ext;
+
+            try {
+                await fs.access(candidate, fs.constants.F_OK);
+                return candidate;
+            } catch { }
+        }
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.


    > Some autocomplete jumped up and I might have accepted one or two before getting annoyed as usual. I don't really remember, it's getting late lol. I changed my approach tho, so probably no AI slop in the final PR.
    >
    > I had it review my pared down which impl to double check I didn't miss anything, it pointed out some mistakes.


## Summary

<!-- Provide a summary of what your change does. -->

On macOS, apps don't pick up the path, so you'd have to manually set the zizmor (see #27). This adds in support for falling back to commonly installed locations. This also handles the case that exePath is an empty string, as the setting GUI is prone to do (as I discovered in testing).

Fixes #29

The implementation is ~~shameless copied~~ heavily based & modified from [JJK's implementation](https://github.com/keanemind/jjk/blob/9b654112563339843e73c87462c1bf0270cf102a/src/repository.ts#L147-L185) [MIT], and also includes portions of [`which`](https://www.npmjs.com/package/which) [ISC] & (trivially) [`@types/which`](npmjs.com/package/@types/which) [MIT].

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

Test with it in path, not in path, etc etc.
Seemed to work for me but should check on Windows, etc.
